### PR TITLE
feat: 윈도우사이즈 반응형 체크 함수 useWindowSize 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,21 @@
+import { useState } from "react";
 import AppRouter from "./AppRouter";
+import useWindowSize from "./common/hooks/useWindowSize";
 
 function App() {
+  const {width, height} = useWindowSize();
+  const {userEnv, setUserEnv} = useState();
+
+
+  useEffect(()=> {
+    if (width >= 1025) setUserEnv("desktop");
+    if (width < 1025 && width > 768) setUserEnv("tablet");
+    if (width <= 768) setUserEnv("mobile");
+  }, [width])
+
   return (
     <div>
-      <AppRouter />
+      <AppRouter userEnv={userEnv}/>
     </div>
   );
 }

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -6,7 +6,7 @@ import FocusPage from "./pages/FocusPage";
 import HabitPage from "./pages/HabitPage";
 import NotFound from "./pages/NotFound";
 
-function AppRouter() {
+function AppRouter({userEnv}) {
   return (
     <BrowserRouter>
       <Routes>

--- a/src/common/hooks/useWindowSize.js
+++ b/src/common/hooks/useWindowSize.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+
+function useWindowSize() {
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined,
+  });
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  return windowSize;
+}
+
+export default useWindowSize;


### PR DESCRIPTION
## 📌 개요

- 사용자의 창 크기에 따라 반응형으로 사용자의 환경을 체크합니다.

## ✨ 주요 변경 사항

- useWindowSize 추가

## 공유 사항(다른 팀원들도 알아두어야 할 것들)

- AppRouter.jsx 에서 userEnv를 Props로 받아서 사용하시면 됩니다.
- userEnv : 가로길이 1025이상은 desktop, 769 부터 1024까지는 tablet, 768 이하는 mobile (전부 string)으로 설정했습니다.

## 🔗 관련 이슈

-
