### PR TITLE
fix/스터디 상세 페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "clsx": "^2.1.1",
         "emoji-picker-react": "^4.12.0",
         "react": "^18.3.1",
+        "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.3",
-        "react-scripts": "^5.0.0"
+        "react-scripts": "^5.0.0",
+        "react-share": "^5.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -6298,6 +6300,12 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -6613,6 +6621,15 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "node_modules/core-js": {
       "version": "3.40.0",
@@ -11570,6 +11587,29 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/jsonpath": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
@@ -14482,6 +14522,19 @@
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
     },
+    "node_modules/react-copy-to-clipboard": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || 16 || 17 || 18"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -15199,6 +15252,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-share": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-5.2.0.tgz",
+      "integrity": "sha512-0gFXnW1qMO4BITbf0lSX03J0GWmYPRqMXcP9obl+T+8nvFeOpqhiow8tGryeY9vx35fprQvri0Q0fkqb3t9uag==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.3.2",
+        "jsonp": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19"
       }
     },
     "node_modules/read-cache": {
@@ -17306,6 +17372,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -17559,9 +17631,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -17569,7 +17641,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "clsx": "^2.1.1",
     "emoji-picker-react": "^4.12.0",
     "react": "^18.3.1",
+    "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^7.1.3",
     "react-scripts": "^5.0.0",
-    "react-router-dom": "^7.1.3"
+    "react-share": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/api/studyApi.js
+++ b/src/api/studyApi.js
@@ -7,3 +7,33 @@ export async function getStudy (studyId) {
     throw err;
   }
 }
+
+export async function verifyPassword (studyId, password) {
+  try{
+    const response = await fetch(`http://localhost:5004/api/studies/verify-password`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type' : 'application/json',
+        },
+        body: JSON.stringify({studyId, password}),
+      }
+    );
+    const verifyData = await response.json();
+    return verifyData;
+  } catch (err) {
+    throw err;
+  }
+}
+
+export async function deleteStudy (studyId) {
+  try{
+    await fetch(`http://localhost:5004/api/studies/${studyId}`,
+      {
+        method: "DELETE",
+      }
+    )
+  } catch (err) {
+    throw err
+  }
+}

--- a/src/common/EmojiTag.jsx
+++ b/src/common/EmojiTag.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const EmojiTag = ({ emoji, count }) => {
   return (
-    <div className="flex items-center gap-1 px-2 py-1 bg-f-black bg-opacity-40 rounded-full text-xs">
+    <div className="flex items-center gap-1 px-2 py-1 bg-f-black bg-opacity-40 rounded-full md:text-sm lg:text-lg">
       <span>{emoji}</span>
       <span className="text-white">{count}</span>
     </div>

--- a/src/common/layout/Header.jsx
+++ b/src/common/layout/Header.jsx
@@ -6,7 +6,7 @@ export function Header({ isCreateButton = false }) {
   return (
     <>
       {isCreateButton ? (
-        <div className="flex lg:ml-48 md:ml-8 ml-2 pt-4 lg:mr-48 md:mr-8 mr-2 lg:mb-8 mb-4 justify-between items-center">
+        <div className="flex  2xl:ml-40 lg:ml-8 md:ml-8 ml-2 pt-4 2xl:mr-40 lg:mr-8 md:mr-8 mr-2 lg:mb-8 mb-4 justify-between items-center">
           <Link to="/">
             <img
               className="md:w-[182px] w-[106px] md:h-[60px] h-[35px]"

--- a/src/common/modal/PasswordModal.jsx
+++ b/src/common/modal/PasswordModal.jsx
@@ -1,78 +1,131 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import hideIcon from "./img/hideEyes.png";
 import openIcon from "./img/openEyes.png";
 import ModalButton from "../buttons/ModalButton";
+import { deleteStudy, verifyPassword } from "@/api/studyApi";
+import ErrorMessage from "../MessageBox";
+import { useNavigate } from "react-router-dom";
 
 const PasswordModal = ({
   isOpen,
   onClose,
-  onVerify,
   title,
-  password,
-  onPasswordChange,
-  isPasswordVisible,
-  onTogglePasswordVisibility,
   buttonText,
-  link,
   studyId,
+  studyData,
 }) => {
   if (!isOpen) return null;
 
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const [password, setPassword] = useState("");
+  const [link, setLink] = useState(``);
+  const [message, setMessage] = useState("");
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (buttonText === "수정하러 가기") setLink(`/study/`);
+    if (buttonText === "스터디 삭제하기") setLink(`/`);
+    if (buttonText === "오늘의 습관으로 가기") setLink(`/habit/`);
+    if (buttonText === "오늘의 집중으로 가기") setLink(`/focus/`);
+  }, []);
+
+  // 토글 기능
+  const onTogglePasswordVisibility = () => {
+    if (isPasswordVisible) setIsPasswordVisible(false);
+    else setIsPasswordVisible(true);
+  };
+
+  // 패스워드 검증 기능
+  const onVerify = async () => {
+    const verifyData = await verifyPassword(studyId, password);
+    console.log(verifyData);
+    if (verifyData.message) {
+      //검증 완료 시
+      setMessage("");
+      if (buttonText !== "스터디 삭제하기") {
+        navigate(link, { state: { studyData, password } });
+        /*
+          이동한 페이지에서 사용할 때
+          const location = useLocation();
+          console.log(location.state);
+        */
+      }
+      else{
+        deleteStudy(studyId);
+        navigate(link);
+      }
+    } else {
+      //검증 실패 시
+      setMessage("비밀번호가 일치하지 않습니다. 다시 입력해주세요.");
+    }
+  };
+
+  const onPasswordChange = (e) => {
+    setPassword(e.target.value);
+  };
+
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
-      <div className="bg-white rounded-[20px] shadow-xl p-6 w-full max-w-[648px] h-[369px] font-sans relative flex flex-col mx-[19px]">
-        <div className="flex items-center justify-center relative mb-6">
-          <h2 className="text-[24px] max-[743px]:text-[18px] font-extrabold text-center flex-1">
-            {title || "비밀번호 확인"}
-          </h2>
-          <div className="hidden min-[744px]:block absolute right-0  mt-4 text-[#578246] hover:text-green-700 ">
-            <button onClick={onClose} isCancel>
-              나가기
-            </button>
+    <>
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+        <div className="bg-white rounded-[20px] shadow-xl p-6 w-full max-w-[648px] h-[369px] font-sans relative flex flex-col mx-[19px]">
+          <div className="flex items-center justify-center relative mb-6">
+            <h2 className="text-[24px] max-[743px]:text-[18px] font-extrabold text-center flex-1">
+              {title || "비밀번호 확인"}
+            </h2>
+            <div className="hidden min-[744px]:block absolute right-0  mt-4 text-[#578246] hover:text-green-700 ">
+              <button onClick={onClose} isCancel>
+                나가기
+              </button>
+            </div>
           </div>
-        </div>
 
-        <p className="text-[18px] font-medium text-[#818181] text-center mb-6">
-          권한이 필요해요!
-        </p>
+          <p className="text-[18px] font-medium text-[#818181] text-center mb-6">
+            권한이 필요해요!
+          </p>
 
-        <label className="text-[18px] font-medium text-black block mb-2">
-          비밀번호
-        </label>
-        <div className="relative">
-          <input
-            type={isPasswordVisible ? "text" : "password"}
-            className="w-full p-3 border rounded-lg pr-12"
-            placeholder="비밀번호를 입력해 주세요"
-            value={password}
-            onChange={onPasswordChange}
-          />
-          <button
-            type="button"
-            onClick={onTogglePasswordVisibility}
-            className="absolute right-4 top-1/2 transform -translate-y-1/2"
-          >
-            <img
-              src={isPasswordVisible ? openIcon : hideIcon}
-              alt={isPasswordVisible ? "비밀번호 숨기기" : "비밀번호 보이기"}
-              className="w-6 h-6"
+          <label className="text-[18px] font-medium text-black block mb-2">
+            비밀번호
+          </label>
+          <div className="relative">
+            <input
+              type={isPasswordVisible ? "text" : "password"}
+              className="w-full p-3 border rounded-lg pr-12"
+              placeholder="비밀번호를 입력해 주세요"
+              value={password}
+              onChange={onPasswordChange}
             />
-          </button>
-        </div>
-
-        <div className="flex flex-col-reverse max-[743px]:flex-col-reverse gap-4 mt-[30px]">
-          <div className="hidden max-[743px]:block mt-4 text-[#578246] hover:text-green-700 text-[16px] font-weight-500 mx-auto">
-            <button onClick={onClose} isCancel className="w-full">
-              나가기
+            <button
+              type="button"
+              onClick={onTogglePasswordVisibility}
+              className="absolute right-4 top-1/2 transform -translate-y-1/2"
+            >
+              <img
+                src={isPasswordVisible ? openIcon : hideIcon}
+                alt={isPasswordVisible ? "비밀번호 숨기기" : "비밀번호 보이기"}
+                className="w-6 h-6"
+              />
             </button>
           </div>
 
-          <ModalButton onClick={() => onVerify(password)} className="w-full">
-            {buttonText}
-          </ModalButton>
+          <div className="flex flex-col-reverse max-[743px]:flex-col-reverse gap-4 mt-[30px]">
+            <div className="hidden max-[743px]:block mt-4 text-[#578246] hover:text-green-700 text-[16px] font-weight-500 mx-auto">
+              <button onClick={onClose} isCancel className="w-full">
+                나가기
+              </button>
+            </div>
+
+            <ModalButton onClick={() => onVerify(password)} className="w-full">
+              {buttonText || 확인}
+            </ModalButton>
+          </div>
+        </div>
+        <div className="absolute bottom-10">
+          {message && <ErrorMessage message={message} isCompleted={false} />}
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/common/modal/PasswordModal.jsx
+++ b/src/common/modal/PasswordModal.jsx
@@ -17,7 +17,6 @@ const PasswordModal = ({
   if (!isOpen) return null;
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-
   const [password, setPassword] = useState("");
   const [link, setLink] = useState(``);
   const [message, setMessage] = useState("");

--- a/src/components/EmojiForm.jsx
+++ b/src/components/EmojiForm.jsx
@@ -6,16 +6,7 @@ import { useEffect, useState } from "react";
 import { getReactions, patchReaction, postReaction } from "@/api/reactionApi";
 
 function EmojiForm({ studyId }) {
-  /*
-  API 데이터를 가져온다 -
-  useState 걸어서 emojis 같은 배열에 객체들을 저장한다. -
-  전체 개수는 따로 구해서 (length-3) 해서 + 버튼에 숫자 표기해준다
-  그 +버튼 누르면 emojis 배열에있는 전체 이모지와 각각의 count를 보여준다.
 
-  이모지가 추가되면 emojis 배열에 이미 존재하면 count+1을 반영해준다.
-  아니면 이모지, count:1 을 추가로 저장한다
-  변경된 내용을 백엔드 서버로 전송한다.
-  */
   const [emojis, setEmojis] = useState([]);
   const [isAddMod, setIsAddMod] = useState(false);
   const [isShowAll, setIsShowAll] = useState(false);
@@ -38,6 +29,15 @@ function EmojiForm({ studyId }) {
     } else setIsShowAll(true);
   };
 
+  const onEmojiTagClick = async (emoji) => {
+    const findEmoji = emojis.find((element) => element.emoji === emoji);
+    setEmojis(emojis.map((element)=> {
+      if(element.emoji === emoji) return {...element, counts: element.counts+1}
+      else return element;
+    }))
+    await patchReaction(studyId, findEmoji.id, {counts: 1})
+  }
+
   const onEmojiClick = async (emojiData) => {
     const isEmoji = emojis.find((element) => emojiData.emoji === element.emoji);
     if (isEmoji) {
@@ -48,7 +48,7 @@ function EmojiForm({ studyId }) {
             : element;
         })
       );
-      const patchData = { counts: isEmoji.counts + 1 };
+      const patchData = { counts: 1 };
       const reactionId = isEmoji.id;
       await patchReaction(studyId, reactionId, patchData);
     } else {
@@ -61,26 +61,28 @@ function EmojiForm({ studyId }) {
 
   return (
     <div className="flex gap-4">
-      <div className="flex gap-2">
+      <div className="flex gap-1">
         {emojis.map((element, index) => {
           if (index < 3)
-            return <EmojiTag emoji={element.emoji} count={element.counts} />;
+            return <div className="cursor-pointer" key={element.emoji} onClick={() => onEmojiTagClick(element.emoji)}><EmojiTag emoji={element.emoji} count={element.counts} /></div>;
         })}
       </div>
       <div className="flex">
         {emojis.length > 3 && (
+          <div className="lg:block hidden">
           <div
-            className="lg:visible invisible cursor-pointer flex gap-1 p-2 rounded-[50px] items-center text-[14px] text-white bg-black opacity-30"
+            className="cursor-pointer flex gap-1 p-2 rounded-[50px] items-center text-[14px] text-white bg-black opacity-30"
             onClick={onShowAllClick}
           >
             <img src={plusImg} />
             {emojis.length - 3}..
           </div>
+          </div>
         )}
         {isShowAll && (
-          <div className="lg:visible invisible pl-5 w-[242px] flex-wrap -translate-x-48 border p-4 gap-1 mt-10 absolute bg-white grid-cols-2 flex rounded-[20px]">
+          <div className="lg:visible invisible pl-5 w-[242px] -translate-x-48 border p-4 gap-1 mt-10 absolute bg-white flex flex-wrap rounded-[20px]">
             {emojis.map((element, index) => {
-              return <EmojiTag emoji={element.emoji} count={element.counts} />;
+              return <div className="h-10 flex items-center cursor-pointer"  onClick={() => onEmojiTagClick(element.emoji)}><EmojiTag emoji={element.emoji} count={element.counts} /></div>;
             })}
           </div>
         )}
@@ -94,7 +96,7 @@ function EmojiForm({ studyId }) {
           <div>추가</div>
         </div>
         {isAddMod && (
-          <div className="absolute mt-3">
+          <div className="absolute mt-3 md:translate-x-0 -translate-x-48">
             <EmojiPicker onEmojiClick={onEmojiClick} />
           </div>
         )}

--- a/src/components/EmojiForm.jsx
+++ b/src/components/EmojiForm.jsx
@@ -68,20 +68,22 @@ function EmojiForm({ studyId }) {
         })}
       </div>
       <div className="flex">
-        <div className="lg:visible invisible cursor-pointer flex gap-1 p-2 rounded-[50px] items-center text-[14px] text-white bg-black opacity-30" onClick={onShowAllClick}>
-          <img src={plusImg}/>
-          {emojis.length - 3}..
-        </div>
-        {
-          isShowAll &&
-          <div className="lg:visible invisible pl-5 w-[242px] flex-wrap -translate-x-48 border p-4 gap-1 mt-10 absolute bg-white grid-cols-2 flex rounded-[20px]">
-            {
-              emojis.map((element, index) => {
-                  return <EmojiTag emoji={element.emoji} count={element.counts} />;
-              })
-            }
+        {emojis.length > 3 && (
+          <div
+            className="lg:visible invisible cursor-pointer flex gap-1 p-2 rounded-[50px] items-center text-[14px] text-white bg-black opacity-30"
+            onClick={onShowAllClick}
+          >
+            <img src={plusImg} />
+            {emojis.length - 3}..
           </div>
-        }
+        )}
+        {isShowAll && (
+          <div className="lg:visible invisible pl-5 w-[242px] flex-wrap -translate-x-48 border p-4 gap-1 mt-10 absolute bg-white grid-cols-2 flex rounded-[20px]">
+            {emojis.map((element, index) => {
+              return <EmojiTag emoji={element.emoji} count={element.counts} />;
+            })}
+          </div>
+        )}
       </div>
       <div>
         <div

--- a/src/components/EmojiForm.jsx
+++ b/src/components/EmojiForm.jsx
@@ -6,7 +6,6 @@ import { useEffect, useState } from "react";
 import { getReactions, patchReaction, postReaction } from "@/api/reactionApi";
 
 function EmojiForm({ studyId }) {
-
   const [emojis, setEmojis] = useState([]);
   const [isAddMod, setIsAddMod] = useState(false);
   const [isShowAll, setIsShowAll] = useState(false);
@@ -30,12 +29,16 @@ function EmojiForm({ studyId }) {
 
   const onEmojiTagClick = async (emoji) => {
     const findEmoji = emojis.find((element) => element.emoji === emoji);
-    setEmojis(emojis.map((element)=> {
-      if(element.emoji === emoji) return {...element, counts: element.counts+1}
-      else return element;
-    }))
-    await patchReaction(studyId, findEmoji.id, {counts: 1})
-  }
+    setEmojis(
+      emojis.map((element) => {
+        if (element.emoji === emoji)
+          return { ...element, counts: element.counts + 1 };
+        else return element;
+      })
+    );
+    await patchReaction(studyId, findEmoji.id, { counts: 1 });
+    setIsChanged(true);
+  };
 
   const onEmojiClick = async (emojiData) => {
     const isEmoji = emojis.find((element) => emojiData.emoji === element.emoji);
@@ -58,30 +61,53 @@ function EmojiForm({ studyId }) {
     setIsAddMod(false);
   };
 
+  useEffect(() => {
+    if(isChanged){
+      const sortedEmojis = [...emojis].sort((a, b) => b.counts - a.counts);
+      setEmojis(sortedEmojis);
+      setIsChanged(false)
+    }
+  }, [isChanged]);
+
   return (
     <div className="flex gap-4">
       <div className="flex gap-1">
         {emojis.map((element, index) => {
           if (index < 3)
-            return <div className="cursor-pointer" key={index} onClick={() => onEmojiTagClick(element.emoji)}><EmojiTag emoji={element.emoji} count={element.counts} /></div>;
+            return (
+              <div
+                className="cursor-pointer"
+                key={index}
+                onClick={() => onEmojiTagClick(element.emoji)}
+              >
+                <EmojiTag emoji={element.emoji} count={element.counts} />
+              </div>
+            );
         })}
       </div>
       <div className="flex">
         {emojis.length > 3 && (
           <div className="lg:block hidden">
-          <div
-            className="cursor-pointer flex gap-1 p-2 rounded-[50px] items-center text-[14px] text-white bg-black opacity-30"
-            onClick={onShowAllClick}
-          >
-            <img src={plusImg} />
-            {emojis.length - 3}..
-          </div>
+            <div
+              className="cursor-pointer flex gap-1 p-2 rounded-[50px] items-center text-[14px] text-white bg-black opacity-30"
+              onClick={onShowAllClick}
+            >
+              <img src={plusImg} />
+              {emojis.length - 3}..
+            </div>
           </div>
         )}
         {isShowAll && (
-          <div className="lg:visible invisible pl-5 w-[242px] -translate-x-48 border p-4 gap-1 mt-10 absolute bg-white flex flex-wrap rounded-[20px]">
+          <div className="lg:visible invisible pl-5 w-[250px] -translate-x-48 border p-4 gap-1 mt-12 absolute bg-white grid grid-cols-3 place-items-center rounded-[20px] ">
             {emojis.map((element, index) => {
-              return <div className="h-10 flex items-center cursor-pointer"  onClick={() => onEmojiTagClick(element.emoji)}><EmojiTag emoji={element.emoji} count={element.counts} /></div>;
+              return (
+                <div
+                  className="h-10 flex items-center cursor-pointer "
+                  onClick={() => onEmojiTagClick(element.emoji)}
+                >
+                  <EmojiTag emoji={element.emoji} count={element.counts} />
+                </div>
+              );
             })}
           </div>
         )}

--- a/src/components/EmojiForm.jsx
+++ b/src/components/EmojiForm.jsx
@@ -11,7 +11,6 @@ function EmojiForm({ studyId }) {
   const [isAddMod, setIsAddMod] = useState(false);
   const [isShowAll, setIsShowAll] = useState(false);
   const [isChanged, setIsChanged] = useState(true);
-  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchReactions = async () => {
@@ -64,7 +63,7 @@ function EmojiForm({ studyId }) {
       <div className="flex gap-1">
         {emojis.map((element, index) => {
           if (index < 3)
-            return <div className="cursor-pointer" key={element.emoji} onClick={() => onEmojiTagClick(element.emoji)}><EmojiTag emoji={element.emoji} count={element.counts} /></div>;
+            return <div className="cursor-pointer" key={index} onClick={() => onEmojiTagClick(element.emoji)}><EmojiTag emoji={element.emoji} count={element.counts} /></div>;
         })}
       </div>
       <div className="flex">

--- a/src/components/ShareModal.jsx
+++ b/src/components/ShareModal.jsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import CopyToClipboard from "react-copy-to-clipboard";
+import {
+  EmailIcon,
+  EmailShareButton,
+  FacebookIcon,
+  FacebookShareButton,
+  InstapaperIcon,
+  InstapaperShareButton,
+  LineIcon,
+  LineShareButton,
+  LinkedinIcon,
+  LinkedinShareButton,
+} from "react-share";
+
+function ShareModal({ onClose, title, description }) {
+  const currentUrl = window.location.href;
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70 z-50">
+      <div className="bg-white rounded-[20px] shadow-xl p-6 w-full max-w-[648px] h-[369px] font-sans relative flex flex-col mx-[19px]">
+        <div className="flex items-center justify-center relative mb-6">
+          <h2 className="text-[24px] max-[743px]:text-[18px] font-extrabold text-center flex-1">
+            공유하기
+          </h2>
+          <div className="hidden min-[744px]:block absolute right-0  mt-4 text-[#578246] hover:text-green-700 ">
+            <button onClick={onClose} isCancel>
+              나가기
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-14 flex justify-center gap-6">
+          <EmailShareButton url={currentUrl} subject={title} body={description}>
+            <EmailIcon size={72} round={true} />
+          </EmailShareButton>
+          <FacebookShareButton url={currentUrl}>
+            <FacebookIcon size={72} round={true} />
+          </FacebookShareButton>
+          <LinkedinShareButton url={currentUrl}>
+            <LinkedinIcon size={72} round={true} />
+          </LinkedinShareButton>
+          <LineShareButton url={currentUrl}>
+            <LineIcon size={72} round={true} />
+          </LineShareButton>
+        </div>
+
+        <div className="flex justify-center text-14pt mt-14 gap-6">
+          <CopyToClipboard text={currentUrl} onCopy={() => setCopied(true)}>
+          {
+            copied? (
+              <div  className="flex justify-center w-60 border p-2 rounded-3xl">
+                 복사 완료되었습니다! ✅
+              </div>
+            ):(
+              <div className="flex justify-center w-60 border p-2 rounded-3xl cursor-pointer hover:bg-stone-100">
+            공유 링크 복사하기 🔗
+          </div>
+            )
+          }
+          </CopyToClipboard>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ShareModal;

--- a/src/pages/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage.jsx
@@ -7,6 +7,7 @@ import PasswordModal from "@/common/modal/PasswordModal";
 import { useEffect, useState } from "react";
 import { getStudy } from "@/api/studyApi";
 import { EarnedPointsBoxMd } from "@/common/EarnedPointsBox";
+import ErrorMessage from "@/common/MessageBox";
 
 function StudyDetailPage() {
   const { studyId } = useParams();
@@ -19,15 +20,14 @@ function StudyDetailPage() {
     const fetchStudy = async () => {
       const data = await getStudy(studyId);
       setStudyData(data);
+      setTitle(data.nickname + "의 " + data.title);
       setIsLoading(false);
     };
     fetchStudy();
-    // setTitle(studyData.nickname + "의 " + studyData.title)
   }, []);
   const enableModal = (e) => {
-    setButtonName(e.target.dataset.name);
+    setButtonName(e.currentTarget.dataset.name);
     setIsModal(true);
-
   };
   const disableModal = (e) => {
     setIsModal(false);
@@ -40,7 +40,7 @@ function StudyDetailPage() {
         <div className="grid place-items-center mt-14">
           <div className="bg-white lg:max-w-[1200px] lg:w-9/12 md:w-10/12 w-11/12 md: rounded-[20px] lg:p-10 md:p-6 p-4">
             <div className="flex md:flex-row flex-col-reverse justify-between gap-3">
-              <EmojiForm studyId={studyId}/>
+              <EmojiForm studyId={studyId} />
               <div className="flex gap-4 md:justify-start justify-end mt-4">
                 <div className="text-[#578246] text-16pt">공유하기</div>
                 <div className="text-[#818181] text-16pt">|</div>
@@ -75,7 +75,8 @@ function StudyDetailPage() {
                 </div>
                 <div
                   className="flex items-center justify-center text-[#818181] border border-[#DDDDDD] md:w-[144px] w-[120px] rounded-2xl text-16pt cursor-pointer md:h-[48px] h-[40px] "
-                  onClick={(e) => enableModal(e)} data-name={"오늘의 집중으로 가기"}
+                  onClick={(e) => enableModal(e)}
+                  data-name={"오늘의 집중으로 가기"}
                 >
                   오늘의 집중 <img src={arrowImg} className="ml-3" />
                 </div>
@@ -96,7 +97,16 @@ function StudyDetailPage() {
           </div>
         </div>
       )}
-      {isModal && <PasswordModal isOpen={true} onClose={disableModal} title={title} studyId={studyId} buttonText={buttonName}/>}
+      {isModal && (
+        <PasswordModal
+          isOpen={true}
+          onClose={disableModal}
+          title={title}
+          buttonText={buttonName}
+          studyId={studyId}
+          studyData={studyData}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage.jsx
@@ -39,7 +39,9 @@ function StudyDetailPage() {
       {!isLoading && (
         <div className="grid place-items-center mt-14">
           <div className="bg-white lg:max-w-[1200px] lg:w-9/12 md:w-10/12 w-11/12 md: rounded-[20px] lg:p-10 md:p-6 p-4">
-            <div className="flex md:flex-row flex-col-reverse justify-between gap-3">
+            {studyData.title? (
+              <>
+              <div className="flex md:flex-row flex-col-reverse justify-between gap-3">
               <EmojiForm studyId={studyId} />
               <div className="flex gap-4 md:justify-start justify-end mt-4">
                 <div className="text-[#578246] text-16pt">공유하기</div>
@@ -94,6 +96,12 @@ function StudyDetailPage() {
             <div className="mt-2">
               <EarnedPointsBoxMd points={studyData.totalPoints} />
             </div>
+            </>
+            ):(
+              <div className="text-center text-32pt">
+                존재하지 않는 스터디입니다.
+                </div>
+            )}
           </div>
         </div>
       )}

--- a/src/pages/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage.jsx
@@ -8,11 +8,13 @@ import { useEffect, useState } from "react";
 import { getStudy } from "@/api/studyApi";
 import { EarnedPointsBoxMd } from "@/common/EarnedPointsBox";
 import ErrorMessage from "@/common/MessageBox";
+import ShareModal from "@/components/ShareModal";
 
 function StudyDetailPage() {
   const { studyId } = useParams();
   const [studyData, setStudyData] = useState();
   const [isModal, setIsModal] = useState(false);
+  const [shareModal, setShareModal] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [title, setTitle] = useState();
   const [buttonName, setButtonName] = useState();
@@ -33,6 +35,14 @@ function StudyDetailPage() {
     setIsModal(false);
   };
 
+  const enableShare = (e) => {
+    setShareModal(true)
+  }
+
+  const disableShare = (e) => {
+    setShareModal(false)
+  }
+
   return (
     <div className="w-full h-screen bg-[#F6F4EF]">
       <Header />
@@ -44,7 +54,7 @@ function StudyDetailPage() {
               <div className="flex md:flex-row flex-col-reverse justify-between gap-3">
               <EmojiForm studyId={studyId} />
               <div className="flex gap-4 md:justify-start justify-end mt-4">
-                <div className="text-[#578246] text-16pt">공유하기</div>
+                <div className="text-[#578246] text-16pt cursor-pointer" onClick={enableShare}>공유하기</div>
                 <div className="text-[#818181] text-16pt">|</div>
                 <div
                   className="text-[#578246] text-16pt cursor-pointer"
@@ -115,6 +125,11 @@ function StudyDetailPage() {
           studyData={studyData}
         />
       )}
+      {
+        shareModal && (
+          <ShareModal onClose={disableShare} title={title} description={studyData.description}/>
+        )
+      }
     </div>
   );
 }


### PR DESCRIPTION
## 📌 개요

- 헤더 반응형 수정, 비밀번호 검증 후 링크이동, 검증 후 스터디 삭제 구현

## ✨ 주요 변경 사항

- 비밀번호 검증 로직 구현
- 완료 후 페이지 이동 (state 담아서)
- 이모지 태그 클릭 시 카운트 추가 기능 구현
- 스터디가 없을 시 페이지 구현
- 공유하기 기능 추가 (netlify 배포 후 다시 테스트 해야 합니다.)

## 공유 사항(다른 팀원들도 알아두어야 할 것들)

![image](https://github.com/user-attachments/assets/ba0587d6-f5a3-4ffd-8c38-2a4ea6bf1f33)

링크 이동하면서 state에 객체 담아서 보내려고 하는데
스터디 수정 페이지, 스터디 집중 페이지, 스터디 습관 수정 페이지에서
위 이미지 주석 처리 된 부분 활용하여 사용 부탁 드립니다.

그리고 상세 스터디 조회 (백엔드) 부분에서 id 출력이 포함되어야 할 것 같습니다.


![image](https://github.com/user-attachments/assets/45cc9e3d-b9c0-40db-8295-2f9cf42340c7)

![image](https://github.com/user-attachments/assets/583eecce-0018-4bc0-9a73-099b82ef664a)

![image](https://github.com/user-attachments/assets/6d52da85-c839-4216-b597-19c83b6e7d09)


![image](https://github.com/user-attachments/assets/0688f13d-6fda-4cb9-9ba6-6697c14e3d26)
삭제된 스터디 확인

![image](https://github.com/user-attachments/assets/793ecc33-26c9-4297-b2b4-bf0774343523)
헤더 수정 부분

![image](https://github.com/user-attachments/assets/6d592416-8e60-4016-b900-12cc59c2ae7b)
존재하지 않는 스터디일 때

![image](https://github.com/user-attachments/assets/014831c9-a7ca-4ec3-b6d3-7b43ebcb349a)
공유하기 기능